### PR TITLE
Mempool

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'bitcoin-ruby',
   # path: '../bitcoin-ruby'
 
 gem 'bitcoin-ruby-blockchain',
-  git: "git://github.com/mhanne/bitcoin-ruby-blockchain"
+  git: "git://github.com/mhanne/bitcoin-ruby-blockchain", branch: "mempool"
   # path: '../bitcoin-ruby-blockchain'
 
 gem 'bitcoin-ruby-wallet',

--- a/bin/bitcoin_node
+++ b/bin/bitcoin_node
@@ -56,6 +56,11 @@ optparse = OptionParser.new do |opts|
     options[:storage] = storage
   end
 
+  opts.on("-m", "--mempool [DB]",
+    "Use given mempool db (default: #{options[:mempool]})") do |mempool|
+    options[:mempool][:db] = mempool
+  end
+
   opts.on("--skip-validation", "Skip validation of blocks and transactions") do
     options[:skip_validation] = true
   end

--- a/lib/bitcoin/node/command_handler.rb
+++ b/lib/bitcoin/node/command_handler.rb
@@ -319,6 +319,17 @@ class Bitcoin::Node::CommandHandler < EM::Connection
     Bitcoin.namecoin? ? {names: @node.store.db[:names].count}.merge(info) : info
   end
 
+  def handle_mempool_stats
+    mempool = @node.store.mempool
+    {
+      total: mempool.transactions.count,
+      accepted: mempool.accepted.count,
+      rejected: mempool.rejected.count,
+      doublespend: mempool.doublespend.count,
+      oldest: (Time.now - mempool.transactions.order(:created_at).first[:created_at]).to_i
+    }
+  end
+
   def add_monitor params, channels
     @monitors << { params: params, channels: channels }
     @monitors.size - 1

--- a/lib/bitcoin/node/connection_handler.rb
+++ b/lib/bitcoin/node/connection_handler.rb
@@ -129,8 +129,8 @@ module Bitcoin::Node
         @node.relay_propagation[hash.hth] += 1
       end
 
-      @node.store.mempool.inv(hash)
-      send_getdata_tx(hash)  unless @node.store.mempool.exists?(hash.hth)
+      return  if @node.inv_queue.size >= @node.config[:max][:inv]
+      @node.queue_inv([:tx, hash, self])
     end
 
     # received +inv_block+ message for given +hash+.
@@ -176,7 +176,7 @@ module Bitcoin::Node
     # push tx to storage queue
     def on_tx(tx)
       log.debug { ">> tx: #{tx.hash} (#{tx.payload.size} bytes)" }
-      @node.store.mempool.add(tx)
+      @node.queue.push([:tx, tx])
     end
 
     # received +block+ message for given +blk+.

--- a/spec/node/command_api_spec.rb
+++ b/spec/node/command_api_spec.rb
@@ -522,10 +522,9 @@ describe 'Node Command API' do
         r1 = send "monitor", channel: "tx"
         should_receive r1, id: 0
         tx = @block.tx[0]
-        r2 = send "store_tx", hex: tx.to_payload.hth
-        should_receive r2, { "queued" => tx.hash }
-
+        r2 = send "store_tx", hex: tx.to_payload.hth, skip_validation: true
         should_receive_tx(r1, tx, 0)
+        should_receive r2, { "added" => tx.hash }
       end
 
       it "should unmonitor tx" do
@@ -537,7 +536,7 @@ describe 'Node Command API' do
 
         tx = @block.tx[0]
         r3 = send "store_tx", hex: tx.to_payload.hth
-        should_receive r3, { "queued" => tx.hash }
+        should_receive r3, { "added" => tx.hash }
 
         test_command("tslb") {|r| (0..TSLB_TIMEOUT).include?(r['tslb']).should == true }
       end
@@ -610,9 +609,9 @@ describe 'Node Command API' do
         r1 = send "monitor", channel: "output"
         should_receive r1, id: 0
         tx = @block.tx[0]
-        r2 = send "store_tx", hex: tx.to_payload.hth
-        should_receive r2, { "queued" => tx.hash }
+        r2 = send "store_tx", hex: tx.to_payload.hth, skip_validation: true
         should_receive_output(r1, tx, 0, 0)
+        should_receive r2, { "added" => tx.hash }
       end
 
       it "should unmonitor outputs" do
@@ -621,7 +620,7 @@ describe 'Node Command API' do
 
         tx = @block.tx[0]
         r2 = send "store_tx", hex: tx.to_payload.hth
-        should_receive r2, { "queued" => tx.hash }
+        should_receive r2, { "added" => tx.hash }
 
         test_command("tslb") {|r| (0..TSLB_TIMEOUT).include?(r['tslb']).should == true }
       end


### PR DESCRIPTION
The Mempool stores unconfirmed transactions to be included in a block.
All transactions are validated and checked for doublespends.
If a doublespend is detected, the doublespending tx is stored separately, and the tx that is being doublespent is flagged.
